### PR TITLE
Make salads more yummy - put :crab: in them

### DIFF
--- a/EFRecipes/assets/expandedfoods/lang/en.json
+++ b/EFRecipes/assets/expandedfoods/lang/en.json
@@ -5994,6 +5994,10 @@
   "pie-single-expandedfoods:crabnugget-raw-partbaked": "Crab pie (part-baked)",
   "pie-single-expandedfoods:crabnugget-raw-perfect": "Crab pie",
   "pie-single-expandedfoods:crabnugget-raw-charred": "Crab pie (charred)",
+  
+  "game:recipeingredient-item-crabmeat-cooked": "Cooked Crab",  
+  "game:recipeingredient-item-crabmeat-partbaked": "Cooked Crab (Part Baked)",  
+  "game:recipeingredient-item-crabmeat-charred": "Cooked Crab (Charred)",  
 
   "game:recipeingredient-item-snakenugget-raw": "snake nuggets",
   "game:recipeingredient-item-snakenugget-raw-insturmentalcase": "snake nuggets",
@@ -9204,4 +9208,5 @@
     "itemdesc-peanutliquid-paste": "A versatile legume paste. Very oily.",
     "itemdesc-peanutliquid-butter": "Thick, dense peanut butter. Sticky and sickly sweet.",
     "itemdesc-peanutliquid-sauce": "Nutty and savory, this sauce tastes great on almost anything.",
+
 }

--- a/EFRecipes/assets/expandedfoods/lang/en.json
+++ b/EFRecipes/assets/expandedfoods/lang/en.json
@@ -5995,6 +5995,9 @@
   "pie-single-expandedfoods:crabnugget-raw-perfect": "Crab pie",
   "pie-single-expandedfoods:crabnugget-raw-charred": "Crab pie (charred)",
   
+  "recipeingredient-item-crabmeat-cooked": "Cooked Crab",  
+  "recipeingredient-item-crabmeat-partbaked": "Cooked Crab (Part Baked)",  
+  "recipeingredient-item-crabmeat-charred": "Cooked Crab (Charred)",    
   "game:recipeingredient-item-crabmeat-cooked": "Cooked Crab",  
   "game:recipeingredient-item-crabmeat-partbaked": "Cooked Crab (Part Baked)",  
   "game:recipeingredient-item-crabmeat-charred": "Cooked Crab (Charred)",  

--- a/EFRecipes/assets/expandedfoods/lang/ja.json
+++ b/EFRecipes/assets/expandedfoods/lang/ja.json
@@ -5995,6 +5995,9 @@
   "pie-single-expandedfoods:crabnugget-raw-perfect": "カニパイ",
   "pie-single-expandedfoods:crabnugget-raw-charred": "カニパイ(黒焦げ)",
   
+  "recipeingredient-item-crabmeat-cooked": "カニの肉(調理済)",  
+  "recipeingredient-item-crabmeat-partbaked": "カニの肉(生焼け)",  
+  "recipeingredient-item-crabmeat-charred": "カニの肉(黒焦げ)",  
   "game:recipeingredient-item-crabmeat-cooked": "カニの肉(調理済)",  
   "game:recipeingredient-item-crabmeat-partbaked": "カニの肉(生焼け)",  
   "game:recipeingredient-item-crabmeat-charred": "カニの肉(黒焦げ)",    

--- a/EFRecipes/assets/expandedfoods/lang/ja.json
+++ b/EFRecipes/assets/expandedfoods/lang/ja.json
@@ -5994,6 +5994,10 @@
   "pie-single-expandedfoods:crabnugget-raw-partbaked": "カニパイ(生焼け)",
   "pie-single-expandedfoods:crabnugget-raw-perfect": "カニパイ",
   "pie-single-expandedfoods:crabnugget-raw-charred": "カニパイ(黒焦げ)",
+  
+  "game:recipeingredient-item-crabmeat-cooked": "カニの肉(調理済)",  
+  "game:recipeingredient-item-crabmeat-partbaked": "カニの肉(生焼け)",  
+  "game:recipeingredient-item-crabmeat-charred": "カニの肉(黒焦げ)",    
 
   "game:recipeingredient-item-snakenugget-raw": "蛇肉ナゲット",
   "game:recipeingredient-item-snakenugget-raw-insturmentalcase": "蛇肉ナゲット",

--- a/EFRecipes/assets/expandedfoods/lang/ru.json
+++ b/EFRecipes/assets/expandedfoods/lang/ru.json
@@ -5612,6 +5612,9 @@
 	"pie-single-expandedfoods:crabnugget-raw-perfect": "Готовый крабовый пирог",
 	"pie-single-expandedfoods:crabnugget-raw-charred": "Подгорелый крабовый пирог",
 
+	"recipeingredient-item-crabmeat-cooked": "Крабовое мясо (приготовленное)",  
+	"recipeingredient-item-crabmeat-partbaked": "Крабовое мясо (частично приготовленное)",  
+	"recipeingredient-item-crabmeat-charred": "Крабовое мясо (обугленное)",  	
 	"game:recipeingredient-item-crabmeat-cooked": "Крабовое мясо (приготовленное)",  
 	"game:recipeingredient-item-crabmeat-partbaked": "Крабовое мясо (частично приготовленное)",  
 	"game:recipeingredient-item-crabmeat-charred": "Крабовое мясо (обугленное)",  	

--- a/EFRecipes/assets/expandedfoods/lang/ru.json
+++ b/EFRecipes/assets/expandedfoods/lang/ru.json
@@ -5612,6 +5612,10 @@
 	"pie-single-expandedfoods:crabnugget-raw-perfect": "Готовый крабовый пирог",
 	"pie-single-expandedfoods:crabnugget-raw-charred": "Подгорелый крабовый пирог",
 
+	"game:recipeingredient-item-crabmeat-cooked": "Крабовое мясо (приготовленное)",  
+	"game:recipeingredient-item-crabmeat-partbaked": "Крабовое мясо (частично приготовленное)",  
+	"game:recipeingredient-item-crabmeat-charred": "Крабовое мясо (обугленное)",  	
+
 	"game:recipeingredient-item-snakenugget-raw": "змеиные кусочки",
 	"game:recipeingredient-item-snakenugget-raw-insturmentalcase": "змеиные кусочки",
 	"recipeingredient-item-snakenugget-raw": "змеиные кусочки",

--- a/EFRecipes/assets/expandedfoods/patches/compatibility/primitivesurvival/recipes/meals/salad.json
+++ b/EFRecipes/assets/expandedfoods/patches/compatibility/primitivesurvival/recipes/meals/salad.json
@@ -464,6 +464,33 @@
       },
       {
         type: "item",
+        code: "primitivesurvival:crabmeat-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "crabmeat-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "primitivesurvival:crabmeat-cooked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "crabmeat-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "primitivesurvival:crabmeat-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "crabmeat-raw"
+        ]
+      },
+      {
+        type: "item",
         code: "expandedfoods:breadedfishnugget-flax-syruppartbaked",
         shapeElement: "bowl/fish/*",
         textureMapping: [

--- a/EFRecipes/assets/expandedfoods/patches/compatibility/primitivesurvival/recipes/meals/salad.json
+++ b/EFRecipes/assets/expandedfoods/patches/compatibility/primitivesurvival/recipes/meals/salad.json
@@ -2,33 +2,1281 @@
   {
     "op": "addeach",
     "path": "/ingredients/5/validStacks/-",
-    "value": [{ type: "item", code: "expandedfoods:sausagefish-normal-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-normal-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-cheese-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-cheese-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagecrab-normal-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-normal-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-cheese-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-cheese-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-normal-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-normal-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-cheese-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-cheese-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagefish-normal-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-normal-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-cheese-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-cheese-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagecrab-normal-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  },  { type: "item", code: "expandedfoods:sausagecrab-normal-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-cheese-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-cheese-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-normal-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-normal-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-cheese-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-cheese-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"] }, { type: "item", code: "expandedfoods:sausagefish-normal-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-normal-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-cheese-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefish-cheese-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagecrab-normal-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-normal-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-cheese-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrab-cheese-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-normal-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-normal-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-cheese-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnake-cheese-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"] }, { type: "item", code: "expandedfoods:fishnugget-tenderpartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:fishnugget-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:fishnugget-tendercharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:fishnugget-cookedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:fishnugget-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:fishnugget-cookedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:crabnugget-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"] }, { type: "item", code: "expandedfoods:crabnugget-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"] }, { type: "item", code: "expandedfoods:crabnugget-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"] }, { type: "item", code: "expandedfoods:snakenugget-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"] }, { type: "item", code: "expandedfoods:snakenugget-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"] }, { type: "item", code: "expandedfoods:snakenugget-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"] }, { type: "item", code: "primitivesurvival:fishfillet-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "fishfillet-raw"] }, { type: "item", code: "primitivesurvival:fishfillet-cooked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "fishfillet-raw"] }, { type: "item", code: "primitivesurvival:fishfillet-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "fishfillet-raw"] }, { type: "item", code: "expandedfoods:breadedfishnugget-flax-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-flax"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rice-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rice"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rye-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rye"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-spelt-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-spelt"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-cassava-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-cassava"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-amaranth-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-amaranth"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-sunflower-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-sunflower"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-flax-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-flax"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rice-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rice"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rye-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rye"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-spelt-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-spelt"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-cassava-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-cassava"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-amaranth-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-amaranth"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-sunflower-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-sunflower"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-flax-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-flax"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rice-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rice"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rye-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rye"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-spelt-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-spelt"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-cassava-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-cassava"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-amaranth-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-amaranth"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-sunflower-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-sunflower"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-flax-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-flax"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rice-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rice"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rye-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rye"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-spelt-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-spelt"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-cassava-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-cassava"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-amaranth-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-amaranth"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-sunflower-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-sunflower"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-flax-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-flax"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rice-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rice"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rye-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rye"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-spelt-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-spelt"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-cassava-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-cassava"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-amaranth-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-amaranth"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-sunflower-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-sunflower"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-flax-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-flax"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rice-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rice"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-rye-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-rye"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-spelt-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-spelt"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-cassava-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-cassava"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-amaranth-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-amaranth"]  }, { type: "item", code: "expandedfoods:breadedfishnugget-sunflower-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-sunflower"]  },],
+    "value": [
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-normal-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-normal-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-cheese-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-cheese-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-normal-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-normal-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-cheese-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-cheese-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-normal-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-normal-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-cheese-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-cheese-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-normal-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-normal-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-cheese-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-cheese-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-normal-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-normal-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-cheese-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-cheese-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-normal-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-normal-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-cheese-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-cheese-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-normal-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-normal-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-cheese-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefish-cheese-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-normal-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-normal-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-cheese-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrab-cheese-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-normal-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-normal-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-cheese-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnake-cheese-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:fishnugget-tenderpartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:fishnugget-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:fishnugget-tendercharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:fishnugget-cookedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:fishnugget-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:fishnugget-cookedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:crabnugget-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:crabnugget-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:crabnugget-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:snakenugget-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:snakenugget-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:snakenugget-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "primitivesurvival:fishfillet-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "primitivesurvival:fishfillet-cooked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "primitivesurvival:fishfillet-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "fishfillet-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-flax-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-flax"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rice-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rice"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rye-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rye"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-spelt-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-spelt"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-cassava-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-cassava"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-amaranth-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-amaranth"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-sunflower-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-sunflower"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-flax-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-flax"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rice-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rice"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rye-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rye"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-spelt-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-spelt"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-cassava-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-cassava"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-amaranth-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-amaranth"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-sunflower-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-sunflower"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-flax-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-flax"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rice-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rice"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rye-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rye"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-spelt-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-spelt"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-cassava-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-cassava"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-amaranth-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-amaranth"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-sunflower-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-sunflower"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-flax-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-flax"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rice-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rice"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rye-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rye"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-spelt-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-spelt"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-cassava-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-cassava"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-amaranth-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-amaranth"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-sunflower-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-sunflower"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-flax-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-flax"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rice-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rice"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rye-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rye"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-spelt-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-spelt"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-cassava-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-cassava"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-amaranth-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-amaranth"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-sunflower-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-sunflower"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-flax-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-flax"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rice-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rice"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-rye-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-rye"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-spelt-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-spelt"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-cassava-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-cassava"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-amaranth-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-amaranth"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:breadedfishnugget-sunflower-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-sunflower"
+        ]
+      },
+    ],
     "file": "recipes/mixing/salad.json",
     "side": "server",
-    dependsOn: [{ "modid": "primitivesurvival" }]
+    dependsOn: [
+      {
+        "modid": "primitivesurvival"
+      }
+    ]
   },
   {
     "op": "addeach",
     "path": "/ingredients/5/validStacks/-",
-    "value": [{ type: "item", code: "expandedfoods:sausagefishherb-normal-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-normal-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-cheese-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-cheese-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-normal-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-normal-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-cheese-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-cheese-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-normal-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-normal-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-cheese-partbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-cheese-driedpartbaked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagefishherb-normal-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-normal-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-cheese-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-cheese-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-normal-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-normal-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-cheese-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-cheese-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-normal-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-normal-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-cheese-cooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-cheese-driedcooked",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagefishherb-normal-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-normal-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-cheese-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagefishherb-cheese-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "poultry-raw"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-normal-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-normal-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-cheese-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagecrabherb-cheese-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "crabmeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-normal-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-normal-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-cheese-charred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  }, { type: "item", code: "expandedfoods:sausagesnakeherb-cheese-driedcharred",  shapeElement: "bowl/meatnugget 1/*", textureMapping: ["meatnugget", "snakemeat"]  },],
+    "value": [
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-normal-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-normal-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-cheese-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-cheese-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-normal-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-normal-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-cheese-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-cheese-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-normal-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-normal-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-cheese-partbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-cheese-driedpartbaked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-normal-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-normal-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-cheese-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-cheese-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-normal-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-normal-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-cheese-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-cheese-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-normal-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-normal-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-cheese-cooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-cheese-driedcooked",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-normal-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-normal-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-cheese-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagefishherb-cheese-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "poultry-raw"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-normal-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-normal-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-cheese-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagecrabherb-cheese-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "crabmeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-normal-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-normal-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-cheese-charred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:sausagesnakeherb-cheese-driedcharred",
+        shapeElement: "bowl/meatnugget 1/*",
+        textureMapping: [
+          "meatnugget",
+          "snakemeat"
+        ]
+      },
+    ],
     "file": "recipes/mixing/salad.json",
     "side": "server",
-    dependsOn: [{ "modid": "primitivesurvival" }, { "modid": "wildcraft" }]
+    dependsOn: [
+      {
+        "modid": "primitivesurvival"
+      },
+      {
+        "modid": "wildcraft"
+      }
+    ]
   },
   {
     "op": "addeach",
     "path": "/ingredients/5/validStacks/-",
-    "value": [{ type: "item", code: "expandedfoods:acornbreadedfishnugget-syruppartbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-acorn-syrup"]  }, { type: "item", code: "expandedfoods:acornbreadedfishnugget-syrups",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-acorn-syrup"]  }, { type: "item", code: "expandedfoods:acornbreadedfishnugget-syrupcharred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-acorn-syrup"]  }, { type: "item", code: "expandedfoods:acornbreadedfishnugget-partbaked",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-acorn-partbaked"]  }, { type: "item", code: "expandedfoods:acornbreadedfishnugget-tender",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-acorn"]  }, { type: "item", code: "expandedfoods:acornbreadedfishnugget-charred",  shapeElement: "bowl/fish/*", textureMapping: ["normal", "breading-acorn-charred"]  },],
+    "value": [
+      {
+        type: "item",
+        code: "expandedfoods:acornbreadedfishnugget-syruppartbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-acorn-syrup"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:acornbreadedfishnugget-syrups",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-acorn-syrup"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:acornbreadedfishnugget-syrupcharred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-acorn-syrup"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:acornbreadedfishnugget-partbaked",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-acorn-partbaked"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:acornbreadedfishnugget-tender",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-acorn"
+        ]
+      },
+      {
+        type: "item",
+        code: "expandedfoods:acornbreadedfishnugget-charred",
+        shapeElement: "bowl/fish/*",
+        textureMapping: [
+          "normal",
+          "breading-acorn-charred"
+        ]
+      },
+    ],
     "file": "recipes/mixing/salad.json",
     "side": "server",
-    dependsOn: [{ "modid": "primitivesurvival" }, { "modid": "acorns" }]
+    dependsOn: [
+      {
+        "modid": "primitivesurvival"
+      },
+      {
+        "modid": "acorns"
+      }
+    ]
   },
   {
     "op": "add",
     "path": "/ingredients/8/validStacks/-",
-    "value": { type: "item", code: "expandedfoods:fishsauce",  shapeElement: "bowl/topping/*", textureMapping: ["topping", "fishsauce"] }, 
+    "value": {
+      type: "item",
+      code: "expandedfoods:fishsauce",
+      shapeElement: "bowl/topping/*",
+      textureMapping: [
+        "topping",
+        "fishsauce"
+      ]
+    },
     "file": "recipes/mixing/salad.json",
     "side": "server",
-    dependsOn: [{ "modid": "primitivesurvival" }]
+    dependsOn: [
+      {
+        "modid": "primitivesurvival"
+      }
+    ]
   },
 ]


### PR DESCRIPTION
Could not add cooked crab meat from primitive survival to salads.

Can do now :grin: 

f3266a9d348884ef552572a445d4d06bb912d68f was just for my sanity. Nothing changed there.

---
I've included the existing localizations for the recipe ingredient from Primitive Survival where they overlap with existing EF localizations, aka en/jp/ru.