### PR TITLE
Make the handbook not lie - actually allow substituting Primitive Survival's :crab: for :fish: in fish broth

### DIFF
--- a/EFRecipes/assets/expandedfoods/patches/compatibility/primitivesurvival/recipes/simmerrecipes.json
+++ b/EFRecipes/assets/expandedfoods/patches/compatibility/primitivesurvival/recipes/simmerrecipes.json
@@ -128,6 +128,14 @@
     dependsOn: [{ "modid": "primitivesurvival", "invert": true }]
   },
   {
+    "file": "expandedfoods:recipes/simmering/primitivesurvival/broth.json",
+    op: "add", 
+    path: "/1/enabled", 
+    value: "false",
+    side: "server",
+    dependsOn: [{ "modid": "primitivesurvival", "invert": true }]
+  },  
+  {
     "file": "expandedfoods:recipes/simmering/primitivesurvival/crabnugget.json",
     op: "add", 
     path: "/0/enabled", 

--- a/EFRecipes/assets/expandedfoods/recipes/simmering/primitivesurvival/broth.json
+++ b/EFRecipes/assets/expandedfoods/recipes/simmering/primitivesurvival/broth.json
@@ -8,7 +8,8 @@
 		},
 		{
 			type: "item",
-			code: "primitivesurvival:fishfillet-partbaked",
+			code: "primitivesurvival:*-partbaked",
+			allowedVariants: ["fishfillet", "crabmeat"],
 			quantity: 2
 		}
 	],

--- a/EFRecipes/assets/expandedfoods/recipes/simmering/primitivesurvival/broth.json
+++ b/EFRecipes/assets/expandedfoods/recipes/simmering/primitivesurvival/broth.json
@@ -26,4 +26,30 @@
 		requiresContainer: false
 	}
 },
+{
+	Ingredients: [
+		{
+			type: "item",
+			code: "waterportion",
+			quantity: 100
+		},
+		{
+			type: "item",
+			code: "primitivesurvival:snakemeat-partbaked",
+			quantity: 2
+		}
+	],
+	Simmering: {
+		meltingPoint: 200,
+		meltingDuration: 110,
+		smeltedRatio: 1,
+		smeltingType: "bake",
+		smeltedStack: {
+			type: "item",
+			code: "expandedfoods:brothportion-meat",
+			"quantity":  50
+		},
+		requiresContainer: false
+	}
+},
 ]


### PR DESCRIPTION
Allows making "fish" broth out of crab meat. 

Handbook _says_ crab can be substituted for fish anywhere 😀 


Also decided against _another_ type of broth, although generalizing "stocks" and allowing multiple types like "bone", "redmeat", "poultry", etc. does sound somewhat appealing.

Oh well, more 🦀 -y goodness for now!