### PR TITLE
Fixes a game crash from handbook when looking at non nugget breaded meat

### DIFF
--- a/EFRecipes/assets/expandedfoods/itemtypes/food/mixing/breadedmeatnugget.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/food/mixing/breadedmeatnugget.json
@@ -75,7 +75,6 @@
 				startScaleY: 1.0,
 				endScaleY: 1.0,
 				resultCode: "expandedfoods:breadedmeatnugget-{type}-{meat}-tender",
-				initialCode: "expandedfoods:breadedmeatnugget-{type}-{meat}-{smashed|oiled}",
 			},
 			"*-tender": {
 				temp: 150,


### PR DESCRIPTION
The game did crash *spectacularly* when looking at breaded meat (the non nugget kind) in the handbook:
```
System.Exception: Can't create itemstack without collectible!
   at Vintagestory.API.Common.ItemStack..ctor(CollectibleObject collectible, Int32 stacksize) in VintagestoryApi\Common\Collectible\ItemStack.cs:line 186
   at Vintagestory.GameContent.CollectibleBehaviorHandbookTextAndExtraInfo.GetHandbookInfo(ItemSlot inSlot, ICoreClientAPI capi, ItemStack[] allStacks, ActionConsumable`1 openDetailPageFor) in VSSurvivalMod\Systems\Handbook\CollectibleBehaviorHandbookTextAndExtraInfo.cs:line 926
   at Vintagestory.GameContent.GuiHandbookItemStackPage.GetPageText(ICoreClientAPI capi, ItemStack[] allStacks, ActionConsumable`1 openDetailPageFor) in VSSurvivalMod\Systems\Handbook\Gui\GuiHandbookItemStackPage.cs:line 110
   at Vintagestory.GameContent.GuiDialogHandbook.initDetailGui() in VSSurvivalMod\Systems\Handbook\Gui\GuiDialogHandbook.cs:line 268
   at Vintagestory.GameContent.GuiElementFlatList.OnMouseUpOnElement(ICoreClientAPI api, MouseEvent args) in VSSurvivalMod\Systems\Handbook\Gui\GuiElementFlatList.cs:line 119
   at Vintagestory.API.Client.GuiElement.OnMouseUp(ICoreClientAPI api, MouseEvent args) in VintagestoryApi\Client\UI\Elements\Impl\GuiElement.cs:line 670
   at Vintagestory.API.Client.GuiComposer.OnMouseUp(MouseEvent mouse) in VintagestoryApi\Client\UI\GuiComposer.cs:line 439
   at Vintagestory.API.Client.GuiDialog.OnMouseUp(MouseEvent args) in VintagestoryApi\Client\UI\Dialog\GuiDialog.cs:line 564
   at Vintagestory.Client.NoObf.GuiManager.OnMouseUp(MouseEvent args) in VintagestoryLib\Client\Systems\Gui\GuiManager.cs:line 416
   at Vintagestory.Client.NoObf.ClientMain.OnMouseUp(MouseEvent args) in VintagestoryLib\Client\ClientMain.cs:line 2286
   at Vintagestory.Client.NoObf.ClientPlatformWindows.Mouse_ButtonUp(Object sender, MouseButtonEventArgs e) in VintagestoryLib\Client\ClientPlatform\Input.cs:line 230
   at System.EventHandler`1.Invoke(Object sender, TEventArgs e)
   at System.EventHandler`1.Invoke(Object sender, TEventArgs e)
   at OpenTK.Platform.Windows.WinGLNative.WindowProcedure(IntPtr handle, WindowMessage message, IntPtr wParam, IntPtr lParam) in C:\Users\Nexrem\Desktop\transfer\opentk\src\OpenTK\Platform\Windows\WinGLNative.cs:line 808
   at OpenTK.Platform.Windows.Functions.DispatchMessage(MSG& msg)
   at OpenTK.Platform.Windows.WinGLNative.ProcessEvents() in C:\Users\Nexrem\Desktop\transfer\opentk\src\OpenTK\Platform\Windows\WinGLNative.cs:line 1551
   at OpenTK.GameWindow.Run(Double updates_per_second, Double frames_per_second) in C:\Users\Nexrem\Desktop\transfer\opentk\src\OpenTK\GameWindow.cs:line 369
   at Vintagestory.Client.ClientProgram.Start(ClientProgramArgs args, String[] rawArgs)
   at Vintagestory.ClientNative.CrashReporter.Start(ThreadStart start) in VintagestoryLib\Client\ClientPlatform\ClientNative\CrashReporter.cs:line 93
   ```
Reason was, it tried to create a stack of `expandedfoods:breadedmeatnugget-{type}-{meat}-{smashed|oiled}` items. Which does not exist. 😱 

Have removed the `initialCode` line. It's not strictly needed since all items correctly declare their baking outputs forward. Checked that both oiled & non oiled meats then correctly bake into their part-baked and final fried variants.

I _thought_ I had written a post in the forum about this crash... cant find it now. bleh...

---

Curious side question: Why is "oiled breaded meat" a thing? It costs the same amount of oil as simply frying things in a cauldron. It yields the absolute same nutrients. It just requires the oiled item then being baked (twice!!) in an oven.
Same inputs, same outputs, just double the work. 😕 