### PR TITLE
Fixes Extended Foods crashing the game in handbook for part baked tree-growing mushrooms

### DIFF
--- a/EFRecipes/assets/expandedfoods/itemtypes/food/cookedmushroom.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/food/cookedmushroom.json
@@ -60,6 +60,22 @@
 		},
 	},
 	attributesByType: {
+		"@*-(beardedtooth|whiteoyster|pinkoyster|dryadsaddle|tinderhoof|chickenofthewoods|reishi|funeralbell|deerear|livermushroom|pinkbonnet|shiitake)-partbaked": {
+			"handbook": { "groupBy": [ "cookedmushroom-*" ] },
+			bakingProperties: {
+				temp: 100,
+				levelFrom: 0.25,
+				levelTo: 0.5,
+				startScaleY: 1.0,
+				endScaleY: 0.9,
+				resultCode: "expandedfoods:cookedmushroom-{mushroom}-perfect",
+				initialCode: "game:mushroom-{mushroom}-normal-north"
+			},
+			onDisplayTransform: { 
+				translation: { x: 0, y: 0, z: 0 },
+				scale: 1 
+			}
+		},		
 		"*-partbaked": {
 			"handbook": { "groupBy": [ "cookedmushroom-*" ] },
 			bakingProperties: {


### PR DESCRIPTION
Game would crash if you opened the handbook entry for the non-chopped part-baked version of any tree growing mushroom.

Fixed that :grin: I like my shiitake crash-less, thank you very much!

Seems tree-growers use a slightly different item code composition.

This should catch them all for now:
![image](https://user-images.githubusercontent.com/324067/213845947-c8f95997-fa01-48f8-a34e-3e34dfc601a3.png)
