### PR TITLE
Lower nutrition from broth in meals

### DIFF
--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/broth.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/broth.json
@@ -12,23 +12,23 @@
 		"inBowlShape": { "base": "game:block/food/meal/liquid" },
 		nutritionPropsWhenInMealByType: {
 			"*-bone": {
-				satiety: 100,
-				health: 1,
+				satiety: 10,
+				health: .1,
 				foodcategory: "Protein"
 			},
 			"*-vegetable": {
-				satiety: 100,
-				health: 1,
+				satiety: 10,
+				health: .1,
 				foodcategory: "Vegetable"
 			},
 			"*-meat": {
-				satiety: 125,
-				health: 1,
+				satiety: 12,5,
+				health: .1,
 				foodcategory: "Protein"
 			},
 			"*-fish": {
-				satiety: 100,
-				health: 1,
+				satiety: 10,
+				health: .1,
 				foodcategory: "Protein"
 			},
 		},


### PR DESCRIPTION
As pointed out on the forum, broth in bread results in very high nutrition value (https://www.vintagestory.at/forums/topic/3783-expanded-foods-165/?page=82#comment-44253:~:text=Broths%20can%20be,1000%20vegetable%20sat). The `nutritionPropsWhenInMealByType` property seems to be per portion (.01 liter), and the dough recipe uses 10 portions, so I'm assuming 1/10 of the previous value was the desired amount. 

With .1L in a dough, the new result is 100 sat and 1 HP for bone broth, instead of 1,000 sat and 10 HP.