### PR TITLE
Fix patch overwriting Wildcraft seeds attributes

### DIFF
--- a/EFRecipes/assets/expandedfoods/patches/compatibility/wildcraft/wildseeds.json
+++ b/EFRecipes/assets/expandedfoods/patches/compatibility/wildcraft/wildseeds.json
@@ -1,44 +1,38 @@
 [
   {
     "op": "add",
-    "path": "/attributes",
+    "path": "/attributes/juiceableProperties",
     "value": {
-      juiceableProperties: {
-			litresPerItem: 0.078125,
-			liquidStack: { type: "item", code: "expandedfoods:foodoilportion-seed", stacksize: 1 },
-			pressedStack: { type: "item", code: "game:pressedmash-seed", stacksize: 1 }
-		},
+      "litresPerItem": 0.078125,
+      "liquidStack": { "type": "item", "code": "expandedfoods:foodoilportion-seed", "stacksize": 1 },
+      "pressedStack": { "type": "item", "code": "game:pressedmash-seed", "stacksize": 1 }
     },
     "file": "wildcraft:itemtypes/resources/herbseeds.json",
     "side": "server",
-    dependsOn: [{ "modid": "wildcraft" }]
+    "dependsOn": [{ "modid": "wildcraft" }]
   },
   {
     "op": "add",
-    "path": "/attributes",
+    "path": "/attributes/juiceableProperties",
     "value": {
-      juiceableProperties: {
-			litresPerItem: 0.078125,
-			liquidStack: { type: "item", code: "expandedfoods:foodoilportion-seed", stacksize: 1 },
-			pressedStack: { type: "item", code: "game:pressedmash-seed", stacksize: 1 }
-		},
+      "litresPerItem": 0.078125,
+      "liquidStack": { "type": "item", "code": "expandedfoods:foodoilportion-seed", "stacksize": 1 },
+      "pressedStack": { "type": "item", "code": "game:pressedmash-seed", "stacksize": 1 }
     },
     "file": "wildcraft:itemtypes/resources/seeds.json",
     "side": "server",
-    dependsOn: [{ "modid": "wildcraft" }]
+    "dependsOn": [{ "modid": "wildcraft" }]
   },
   {
     "op": "add",
-    "path": "/attributes",
+    "path": "/attributes/juiceableProperties",
     "value": {
-      juiceableProperties: {
-			litresPerItem: 0.078125,
-			liquidStack: { type: "item", code: "expandedfoods:foodoilportion-seed", stacksize: 1 },
-			pressedStack: { type: "item", code: "game:pressedmash-seed", stacksize: 1 }
-		},
+      "litresPerItem": 0.078125,
+      "liquidStack": { "type": "item", "code": "expandedfoods:foodoilportion-seed", "stacksize": 1 },
+      "pressedStack": { "type": "item", "code": "game:pressedmash-seed", "stacksize": 1 }
     },
     "file": "wildcraft:itemtypes/resources/waterherbseeds.json",
     "side": "server",
-    dependsOn: [{ "modid": "wildcraft" }]
-  },
+    "dependsOn": [{ "modid": "wildcraft" }]
+  }
 ]


### PR DESCRIPTION
As is, the patch file wildseeds.json overwrites the attributes section of the files. Moving juiceableProperties to path maintains the existing attributes while adding the intended effects.