### PR TITLE
Change default gelatin foodcategory to Protein

### DIFF
--- a/EFRecipes/assets/expandedfoods/itemtypes/food/gelatin.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/food/gelatin.json
@@ -65,7 +65,7 @@
 		"*-crowseye": { saturation: 200, health: -23, foodcategory: "Fruit" },
 		"*-soy": { saturation: 200, health: 3, foodcategory: "Protein" },
 		"*-plain": { saturation: 150, health: 1, foodcategory: "Protein" },
-		"*": { saturation: 200, health: 3, foodcategory: "Fruit" },
+		"*": { saturation: 200, health: 3, foodcategory: "Protein" },
 	},
 	creativeinventory: { "general": ["*"], "items": ["*"], "expandedfoods": ["*"] },
 	maxstacksizeByType: {


### PR DESCRIPTION
Change gelatin's default foodcategory to Protein in `EFRecipes/EFRecipes/assets/expandedfoods/itemtypes/food/gelatin.json`. Fixes #48.