### PR TITLE
Fix crashes for Avocado and Pomace alcohols

### DIFF
--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentspirit.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentspirit.json
@@ -3,7 +3,7 @@
 	class: "TransLiquid",
 	matterState: "liquid",
 	variantgroups: [
-		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper"] },
+		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado"] },
 	],
 	"skipVariants": ["*-pittedcherry", "*-pittedapricot", "*-pittedbreadfruit", "*-cashewwhole", "*-chinaberry", "*-beachalmondwhole", "*-lillypillywhite", "*-lillypillyblue", "*-lemon", "*-blacknightshadeunripe"],
 	attributes: {

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentspirit.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentspirit.json
@@ -3,7 +3,7 @@
 	class: "TransLiquid",
 	matterState: "liquid",
 	variantgroups: [
-		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado"] },
+		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado", "grappa"] },
 	],
 	"skipVariants": ["*-pittedcherry", "*-pittedapricot", "*-pittedbreadfruit", "*-cashewwhole", "*-chinaberry", "*-beachalmondwhole", "*-lillypillywhite", "*-lillypillyblue", "*-lemon", "*-blacknightshadeunripe"],
 	attributes: {

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentwine.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentwine.json
@@ -3,7 +3,7 @@
 	class: "TransLiquid",
 	matterState: "liquid",
 	variantgroups: [
-		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper"] },
+		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado", "pomace"] },
 	],
 	"skipVariants": ["*-pittedcherry", "*-pittedapricot", "*-pittedbreadfruit", "*-cashewwhole", "*-chinaberry", "*-beachalmondwhole", "*-lillypillywhite", "*-lillypillyblue", "*-lemon", "*-blacknightshadeunripe"],
 	attributes: {

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentwine.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildpotentwine.json
@@ -46,9 +46,13 @@
 			},
 		},
 		"distillationPropsbytype": {		
+			"*-pomace": {
+				"distilledStack": { "type": "item", "code": "expandedfoods:wildstrongspiritportion-grappa" },
+				"ratio": 0.4
+			},		
 			"*": {
-			"distilledStack": { "type": "item", "code": "wildcraftfruit:spiritportion-{fruit}" },
-			"ratio": 0.4
+				"distilledStack": { "type": "item", "code": "wildcraftfruit:spiritportion-{fruit}" },
+				"ratio": 0.4
 			}
 		},
 	},

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongspirit.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongspirit.json
@@ -3,7 +3,7 @@
 	class: "TransLiquid",
 	matterState: "liquid",
 	variantgroups: [
-		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper"] },
+		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado"] },
 	],
 	"skipVariants": ["*-pittedcherry", "*-pittedapricot", "*-pittedbreadfruit", "*-cashewwhole", "*-chinaberry", "*-beachalmondwhole", "*-lillypillywhite", "*-lillypillyblue", "*-lemon", "*-blacknightshadeunripe"],
 	attributes: {

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongspirit.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongspirit.json
@@ -3,7 +3,7 @@
 	class: "TransLiquid",
 	matterState: "liquid",
 	variantgroups: [
-		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado"] },
+		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado", "grappa"] },
 	],
 	"skipVariants": ["*-pittedcherry", "*-pittedapricot", "*-pittedbreadfruit", "*-cashewwhole", "*-chinaberry", "*-beachalmondwhole", "*-lillypillywhite", "*-lillypillyblue", "*-lemon", "*-blacknightshadeunripe"],
 	attributes: {

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongwine.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongwine.json
@@ -46,9 +46,13 @@
 			},
 		},
 		"distillationPropsbytype": {		
+			"*-pomace": {
+				"distilledStack": { "type": "item", "code": "expandedfoods:wildstrongspiritportion-grappa" },
+				"ratio": 0.2
+			},	
 			"*": {
-			"distilledStack": { "type": "item", "code": "wildcraftfruit:spiritportion-{fruit}" },
-			"ratio": 0.2
+				"distilledStack": { "type": "item", "code": "wildcraftfruit:spiritportion-{fruit}" },
+				"ratio": 0.2
 			}
 		},
 	},

--- a/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongwine.json
+++ b/EFRecipes/assets/expandedfoods/itemtypes/liquid/wildcraftfruit/wildstrongwine.json
@@ -3,7 +3,7 @@
 	class: "TransLiquid",
 	matterState: "liquid",
 	variantgroups: [
-		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper"] },
+		{ code: "fruit", "loadFromProperties": "wildcraftfruit:block/fruit", "states": ["sumac", "juniper", "avocado", "pomace"] },
 	],
 	"skipVariants": ["*-pittedcherry", "*-pittedapricot", "*-pittedbreadfruit", "*-cashewwhole", "*-chinaberry", "*-beachalmondwhole", "*-lillypillywhite", "*-lillypillyblue", "*-lemon", "*-blacknightshadeunripe"],
 	attributes: {

--- a/EFRecipes/assets/expandedfoods/lang/en.json
+++ b/EFRecipes/assets/expandedfoods/lang/en.json
@@ -15611,6 +15611,46 @@
   "game:incontainer-item-wildpotentspiritportion-mingimingi": "Vintage mingimingi brandy",
   "recipeingredient-item-wildpotentspiritportion-mingimingi-insturmentalcase": "vintage mingimingi brandy",
 
+  "item-wildstrongspiritportion-avocado": "Aged avocado brandy portion",
+  "incontainer-item-wildstrongspiritportion-avocado": "Aged avocado brandy",
+  "game:incontainer-item-wildstrongspiritportion-avocado": "Aged avocado brandy",
+  "recipeingredient-item-wildstrongspiritportion-avocado-insturmentalcase": "aged avocado brandy",
+
+  "item-wildpotentspiritportion-avocado": "Vintage avocado brandy portion",
+  "incontainer-item-wildpotentspiritportion-avocado": "Vintage avocado brandy",
+  "game:incontainer-item-wildpotentspiritportion-avocado": "Vintage avocado brandy",
+  "recipeingredient-item-wildpotentspiritportion-avocado-insturmentalcase": "vintage avocado brandy",
+
+  "item-wildstrongwineportion-avocado": "Strong avocado wine portion",
+  "incontainer-item-wildstrongwineportion-avocado": "Strong avocado wine",
+  "game:incontainer-item-wildstrongwineportion-avocado": "Strong avocado wine",
+  "recipeingredient-item-wildstrongwineportion-avocado-insturmentalcase": "strong avocado wine",
+
+  "item-wildpotentwineportion-avocado": "Fine avocado wine portion",
+  "incontainer-item-wildpotentwineportion-avocado": "Fine avocado wine",
+  "game:incontainer-item-wildpotentwineportion-avocado": "Fine avocado wine",
+  "recipeingredient-item-wildpotentwineportion-avocado-insturmentalcase": "fine avocado wine",
+
+  "item-wildstrongspiritportion-grappa": "Aged grappa portion",
+  "incontainer-item-wildstrongspiritportion-grappa": "Aged grappa",
+  "game:incontainer-item-wildstrongspiritportion-grappa": "Aged grappa",
+  "recipeingredient-item-wildstrongspiritportion-grappa-insturmentalcase": "aged grappa",
+
+  "item-wildpotentspiritportion-grappa": "Vintage grappa portion",
+  "incontainer-item-wildpotentspiritportion-grappa": "Vintage grappa",
+  "game:incontainer-item-wildpotentspiritportion-grappa": "Vintage grappa",
+  "recipeingredient-item-wildpotentspiritportion-grappa-insturmentalcase": "vintage grappa",
+
+  "item-wildstrongwineportion-pomace": "Strong pomace wine portion",
+  "incontainer-item-wildstrongwineportion-pomace": "Strong pomace wine",
+  "game:incontainer-item-wildstrongwineportion-pomace": "Strong pomace wine",
+  "recipeingredient-item-wildstrongwineportion-grappa-insturmentalcase": "strong pomace wine",
+
+  "item-wildpotentwineportion-pomace": "Fine pomace wine portion",
+  "incontainer-item-wildpotentwineportion-pomace": "Fine pomace wine",
+  "game:incontainer-item-wildpotentwineportion-pomace": "Fine pomace wine",
+  "recipeingredient-item-wildpotentwineportion-grappa-insturmentalcase": "fine pomace wine",
+
   "item-wildfruitsyrupportion-cocoa": "Cocoa syrup portion",
   "incontainer-item-wildfruitsyrupportion-cocoa": "Cocoa syrup",
   "game:incontainer-item-wildfruitsyrupportion-cocoa": "Cocoa syrup",

--- a/EFRecipes/assets/expandedfoods/patches/compatibility/wildcraftfruit/disableagedalcohol.json
+++ b/EFRecipes/assets/expandedfoods/patches/compatibility/wildcraftfruit/disableagedalcohol.json
@@ -25,7 +25,7 @@
     "side": "server",
     op: "replace", 
     path: "/attributes/distillationPropsbytype/*-pomace/distilledStack/code", 
-    value: "expandedfoods:wildstrongspirit-grappa",
+    value: "expandedfoods:wildstrongspiritportion-grappa",
  },
 
 


### PR DESCRIPTION
## Description
This is a fix for #58. There are 2 changes to fix this:
- Adds Avocado & Pomace to strong/potent Wildcraft cider, so that base ciders of both types can correctly age up the chain
- Adds Avocado to strong/potent Wildcraft spirit, so that base Avocado spirit can correctly age up the chain
- Adds support for Grappa to strong/potent Wildcraft spirit, which is made from Pomace wine. Required a specific DistillationProperty on the ciders, as the base, non-strong Grappa spirit does not exist
- Fixes a typo in `disableagedalcohol.json`. It looks like Pomace wine was intended to distill directly to Strong Grappa, but that referenced the wrong item code. This meant any attempt to load the Pomace wine handbook page would immediately crash
- Adds lang references to the EN lang file for Avocado and Pomace alcohols, grappa, etc.

## Testing
- Loaded up a test world with my changes and verified that the Handbook crashes I had been seeing are no longer occurring
- Verified that the language file was working and I was seeing the right names for everything
- <img width="861" height="1009" alt="Screenshot 2025-07-15 135129" src="https://github.com/user-attachments/assets/65ed208b-fc5f-4414-bb0b-2f6a05872241" />
- <img width="854" height="1004" alt="Screenshot 2025-07-15 135144" src="https://github.com/user-attachments/assets/c4419262-9370-4954-86b2-59f352251dba" />


## Issues
- I don't speak other languages, so cannot update the other non-English lang files
- Basic Avocado brandy doesn't seem to show up in the Handbook for some reason